### PR TITLE
Run codestyle test in github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,16 @@ jobs:
 
   # This doesn't run on the Atlas board
   codestyle:
-    runs-on: self-hosted
+    runs-on: ubuntu-18.04
 
     steps:
       # Checks-out your repository
       - uses: actions/checkout@v2
+
+      - name: Set up Python 3.7.5
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7.5
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           python-version: 3.7.5
 
-      - name: Set environment variables
-        run: |
-          echo "PYTHONPATH=$PYTHONPATH:$HOME/Ascend/ascend-toolkit/latest/pyACL/python/site-packages/acl" >> $GITHUB_ENV
-
       - name: Set up environment
         run: bash Webservice/scripts/setup.sh --yes
 


### PR DESCRIPTION
The code style check doesn't have to run on the Atlas Board, the acl stuff is not required.

This change makes in run in Github, which results in less workload on my device and faster results for you 