### PR TITLE
only handle runtimeerrors, let flask handle the rest 

### DIFF
--- a/colorization/atlas_utils/utils.py
+++ b/colorization/atlas_utils/utils.py
@@ -4,8 +4,8 @@ from .lib.atlasutil_so import libatlas
 
 def check_ret(message, ret):
     if ret != ACL_ERROR_NONE:
-        raise Exception("{} failed ret={}"
-                        .format(message, ret))
+        raise RuntimeError("{} failed ret={}"
+                           .format(message, ret))
 
 def copy_data_device_to_host(device_data, data_size):
     host_buffer, ret = acl.rt.malloc_host(data_size)

--- a/webservice/app.py
+++ b/webservice/app.py
@@ -259,7 +259,7 @@ def get_name(filename):
     return filename.rsplit('.', 1)[0]
 
 
-@app.errorhandler(Exception)
+@app.errorhandler(RuntimeError)
 def handle_error(e):
     print('------------------')
     print('ERROR HANDLER CALLED')


### PR DESCRIPTION
currently this handler handles all python exceptions including ones for 404 which we want flask to handle itself