### PR TITLE
Add sphinx themes + mock to requirements, generate documentation again

### DIFF
--- a/docs/colorization.html
+++ b/docs/colorization.html
@@ -208,14 +208,10 @@
 <dt class="sig sig-object py" id="colorization.colorize_process.inference">
 <span class="sig-prename descclassname"><span class="pre">colorization.colorize_process.</span></span><span class="sig-name descname"><span class="pre">inference</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">model_path</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">input_image</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#colorization.colorize_process.inference" title="Permalink to this definition">¶</a></dt>
 <dd><p>This function activate the model process after preprocess,
-and get result back.
-Parameters:
-———–
-model_path: str</p>
-<blockquote>
-<div><p>the path of offline model(<a href="#id1"><span class="problematic" id="id2">*</span></a>.om file)</p>
-</div></blockquote>
+and get result back.</p>
 <dl class="simple">
+<dt>model_path: str</dt><dd><p>the path of offline model(<a href="#id1"><span class="problematic" id="id2">*</span></a>.om file)</p>
+</dd>
 <dt>input_image: numpy array</dt><dd><p>resized image with L_channel obtained from preprocess.</p>
 </dd>
 <dt>result<span class="classifier">numpy array</span></dt><dd><p>ab channels of the preprocessed image.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest-cov==2.12.0
 
 # sphinx
 sphinx==4.0.2
+sphinx-rtd-theme==0.5.2
+mock==4.0.3

--- a/scripts/generate_documentation.sh
+++ b/scripts/generate_documentation.sh
@@ -16,15 +16,22 @@ echo "======================================================================"
 echo "Generating Documentation"
 echo "======================================================================"
 
-venv/bin/sphinx-apidoc -o sphinx/source/ colorization
-venv/bin/sphinx-apidoc -o sphinx/source/ webservice
+
+source venv/bin/activate
+
+sphinx-apidoc -o sphinx/source/ colorization
+sphinx-apidoc -o sphinx/source/ webservice
+
 cd sphinx
 make clean
 make html
 cd ..
+
 rm -r docs/*
 cp -r sphinx/build/html/* docs/
 cp -r sphinx/build/html/.buildinfo docs/
+
+deactivate
 
 if [ $HOSTNAME != "davinci-mini" ]; then
     xdg-open docs/index.html

--- a/scripts/generate_documentation.sh
+++ b/scripts/generate_documentation.sh
@@ -17,6 +17,7 @@ echo "Generating Documentation"
 echo "======================================================================"
 
 
+# enter virtual environment
 source venv/bin/activate
 
 sphinx-apidoc -o sphinx/source/ colorization
@@ -31,6 +32,7 @@ rm -r docs/*
 cp -r sphinx/build/html/* docs/
 cp -r sphinx/build/html/.buildinfo docs/
 
+# leave virtual environment
 deactivate
 
 if [ $HOSTNAME != "davinci-mini" ]; then


### PR DESCRIPTION
this also runs the sphinx make commands inside the python virtualenv so it can access the sphinx library

enter the venv with 'source venv/bin/activate'
leave it with 'deactivate'